### PR TITLE
Add query function to PackConfigDict

### DIFF
--- a/st2common/st2common/runners/utils.py
+++ b/st2common/st2common/runners/utils.py
@@ -81,6 +81,22 @@ class PackConfigDict(dict):
     def __setitem__(self, key, value):
         super(PackConfigDict, self).__setitem__(key, value)
 
+    def query(self, yaql_expression, default=None):
+        """
+        Evaluate a YAQL expression against the pack config
+        """
+
+        # late import to avoid performance overhead in packs that do not need this functionality
+        import yaql
+
+        engine = yaql.factory.YaqlFactory().create()
+        expression = engine(yaql_expression)
+
+        try:
+            return expression.evaluate(data=self)
+        except KeyError:
+            return default
+
 
 def get_logger_for_python_runner_action(action_name, log_level='debug'):
     """


### PR DESCRIPTION
Evaluates a YAQL expression against the contents of a
PackConfigDict, useful for evaluating objects of configuration
items within a pack config, or selecting configuration options
based on action input parameters.